### PR TITLE
feat:Implements start session button, and end session button. 

### DIFF
--- a/CES_Device_Simulator/Battery.cpp
+++ b/CES_Device_Simulator/Battery.cpp
@@ -5,6 +5,14 @@ Battery::Battery(int n) : powerLevel(n)
 
 }
 
+int Battery::getPowerLevel(){
+    return powerLevel;
+}
+
+void Battery::setPowerLevel(int value){
+    powerLevel = value;
+}
+
 int Battery::decrement(int n)
 {
     powerLevel -= n;

--- a/CES_Device_Simulator/Battery.h
+++ b/CES_Device_Simulator/Battery.h
@@ -8,6 +8,8 @@ public:
     Battery(int);
     int batteryPercentage = 100;
     int decrement(int);
+    int getPowerLevel();
+    void setPowerLevel(int);
 private:
     int powerLevel;
 };

--- a/CES_Device_Simulator/Session.cpp
+++ b/CES_Device_Simulator/Session.cpp
@@ -1,7 +1,10 @@
 #include "Session.h"
 
-Session::Session(int i, int l, Type t, Connection c) : initlength(l), intensity(i), type(t), length(0), connection(c)
+Session::Session(int i, int l, Type t, Connection c) : initlength(l), length(0), intensity(i), type(t), connection(c)
 {
+    timer = new QTimer(this);
+    loop = new QEventLoop();
+    sessionFlag = false;
 }
 
 int Session::changeIntensity(int i)
@@ -34,4 +37,59 @@ Type Session::getType()
 Connection Session::getConnection()
 {
     return connection;
+}
+
+void Session::setSessionFlag(bool flag){
+    sessionFlag = flag;
+}
+
+void Session::setBattery(Battery* b){
+    battery = b;
+}
+
+void Session::startSession(int sessionLength, int intensity, bool record, Type option){
+    int count = 0;
+    qInfo("%d",intensity);
+    qInfo("%d", record);
+
+    if (option == ALPHA){
+        type = ALPHA;
+    }else if(option == THETA){
+        type = THETA;
+    }else if(option == DELTA){
+        type = DELTA;
+    }else if(option == MET){
+        type = MET;
+    }
+
+    while(sessionFlag){
+        qInfo("battery: %d", battery->getPowerLevel());
+        int depletionRate = 1;
+
+        connect(timer, &QTimer::timeout, loop, &QEventLoop::quit);
+        timer->setSingleShot(true);
+        timer->start(500);
+        loop->exec();
+        count++;
+        battery->decrement(depletionRate);
+        if(battery->getPowerLevel() == 3){
+            qInfo("Low battery");
+            qInfo("Ending session...");
+            return;
+        }
+        if(count == sessionLength){
+            sessionFlag = false;
+            qInfo("Finished Session...");
+            return;
+        }
+    }
+}
+
+void Session::endSession(){
+    timer->stop();
+    loop->quit();
+    timer = new QTimer(this);
+    loop = new QEventLoop();
+    sessionFlag = false;
+    qInfo("Ending Session...");
 }

--- a/CES_Device_Simulator/Session.h
+++ b/CES_Device_Simulator/Session.h
@@ -1,24 +1,39 @@
 #ifndef SESSION_H
 #define SESSION_H
 
+#include <QObject>
 #include "Defs.h"
+#include "QtGlobal"
+#include "QEventLoop"
+#include "QTimer"
+#include "Battery.h"
 
-class Session
+class Session : public QObject
 {
+    Q_OBJECT
+
 public:
     Session(int = 0, int = 0, Type = MET, Connection = NONE);
     int changeIntensity(int);
     int incrementLength(int);
     int getLength();
     int getIntensity();
+    void setSessionFlag(bool);
+    void setBattery(Battery*);
+    void startSession(int, int, bool, Type);
+    void endSession();
     Type getType();
     Connection getConnection();
 private:
     int initlength;
     int length;
     int intensity;
+    bool sessionFlag;
     Type type;
     Connection connection;
+    QEventLoop* loop;
+    QTimer* timer;
+    Battery* battery;
 
 };
 

--- a/CES_Device_Simulator/mainwindow.cpp
+++ b/CES_Device_Simulator/mainwindow.cpp
@@ -8,13 +8,15 @@ MainWindow::MainWindow(QWidget *parent)
     ui->setupUi(this);
     connect(ui->btnPowerOn, SIGNAL(released()), this, SLOT(powerOn()));
     connect(ui->btnPowerOff, SIGNAL(released()), this, SLOT(powerOff()));
+    connect(ui->btnStartSession, SIGNAL(released()), this, SLOT(runSession()));
+    connect(ui->btnEndSession, SIGNAL(released()), this, SLOT(endSession()));
 }
 
 
 void MainWindow::runSession(){
-
-    int intensity = ui->barIntensityBar->value();
-
+    currentSession = new Session(0, 0, MET, NONE);
+    int intensity = ui->barIntensity->value();
+    int length = 0;
     bool record = ui->ckRecordSession->isChecked();
 
     Type type;
@@ -27,6 +29,16 @@ void MainWindow::runSession(){
     }else if(ui->rbMetOption->isChecked()){
         type = MET;
     }
+
+    if(ui->rbTwentyOption->isChecked()){
+        length = 20;
+    }else if(ui->rbFortyFiveOption->isChecked()){
+        length = 45;
+    }
+
+    currentSession->setSessionFlag(true);
+    currentSession->setBattery(battery);
+    currentSession->startSession(length, intensity, record, type);
 
     Connection connection;
 
@@ -42,15 +54,11 @@ void MainWindow::runSession(){
     //Test connection
     testConnection(connection,false);
     //do while loop to run through session
-
     //
-
-
-
 }
 
 void MainWindow::endSession(){
-    stop = true;
+    currentSession->endSession();
 }
 
 bool MainWindow::testConnection(Connection connection, bool start){

--- a/CES_Device_Simulator/mainwindow.h
+++ b/CES_Device_Simulator/mainwindow.h
@@ -20,8 +20,7 @@ class MainWindow : public QMainWindow
 public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
-    void runSession();
-    void endSession();
+
     void saveData();
     void changeIntensity(int);
     void turnOn();
@@ -33,11 +32,13 @@ private:
     Ui::MainWindow *ui;
     Battery* battery = new Battery(100);
     int intensity = 0;
-    Session currentSession;
+    Session* currentSession;
     Session* sessions = new Session[50];
 
 private slots:
     void powerOn();
     void powerOff();
+    void runSession();
+    void endSession();
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
This allows the user to click start session, and will immediately deplete the battery. The user can also click end session, and will stop the session running and stop the battery from being depleted.